### PR TITLE
fix: change to disabled for by policy hits

### DIFF
--- a/.github/workflows/wiz-dir-scan.yml
+++ b/.github/workflows/wiz-dir-scan.yml
@@ -107,7 +107,7 @@ jobs:
           sudo -E ${{ env.WIZCLI_PATH }} scan dir "." \
           --name "${{ github.repository }}-${{ matrix.tenant }}-${{ github.run_id }}" --tag github_action_run_id=${{ github.run_id }} \
           --tag tenant=${{ matrix.tenant }} --tag deploy_env=${{ matrix.deploy_env }} --sarif-output-file "${{ matrix.tenant }}-${{ github.run_id }}.json" --sbom-format spdx-json \
-          --sbom-output-file "${{ matrix.tenant }}-${{ github.run_id }}-sbom.json" --by-policy-hits="AUDIT"
+          --sbom-output-file "${{ matrix.tenant }}-${{ github.run_id }}-sbom.json" --by-policy-hits="DISABLED"
         env:
           WIZ_ENV: ${{ matrix.deploy_env }}
         continue-on-error: true


### PR DESCRIPTION
This pull request updates the Wiz directory scan workflow configuration to change how policy hits are handled during scans.

Configuration update:

* [`.github/workflows/wiz-dir-scan.yml`](diffhunk://#diff-5f570ce2f4c21909bada6829fdf262a5f345a67e9776d026f2d6dfb3a59171baL110-R110): The `--by-policy-hits` option in the Wiz CLI scan command is changed from `"AUDIT"` to `"DISABLED"`, which alters the behavior for policy hit reporting during the scan.